### PR TITLE
#89 Add badge to show status of latest release CI run

### DIFF
--- a/.github/workflows/htmlize.yml
+++ b/.github/workflows/htmlize.yml
@@ -1,5 +1,11 @@
 name: Build dashboard
-on: [push]
+
+on:
+  push:
+    branches: [ master, main ]
+    tags: [ v* ]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   readme:

--- a/.github/workflows/htmlize.yml
+++ b/.github/workflows/htmlize.yml
@@ -24,22 +24,24 @@ jobs:
       - name: Build release dashboard
         run: make all
 
-      - name: Configure Git
+      - name: Print README.adoc
+        run: cat README.adoc
+
+      - name: Commit release dashboard
+        if: github.event_name != 'pull_request'
+        id: commit
         run: |
           git config --local user.email "open.source@ribose.com"
           git config --local user.name "GitHub Action"
-
-      - name: Commit release dashboard
-        id: commit
-        run: |
           mv README.adoc .github/README.adoc
           git add -f .github/README.adoc
           git commit -m "Build release dashboard"
         continue-on-error: true
 
       - name: Push changes
-        if: success()
+        if: success() && github.event_name != 'pull_request'
         uses: ad-m/github-push-action@v0.5.0
         with:
           branch: ${{ github.ref }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.adoc.erb
+++ b/README.adoc.erb
@@ -11,6 +11,7 @@ WARNING: This repository is for INTERNAL USE ONLY.
 <% for name in %w[html2doc isodoc metanorma-standoc metanorma-iso metanorma-generic metanorma-ietf metanorma-itu metanorma-mpfa metanorma-nist metanorma-ogc metanorma-un metanorma-iec metanorma-bsi metanorma-bipm metanorma-csa metanorma-cc metanorma-iho metanorma-m3aawg metanorma-ribose metanorma metanorma-cli] %>
 <%= github_link "metanorma", name %> <%= shield_gem name %>::
 <%= shield_gha_rake "metanorma", name %>
+<%= shield_gha_latest_release "metanorma", name %>
 <%= shield_code_climate "metanorma", name %>
 <%= shield_pull_requests "metanorma", name %>
 <%= shield_commits_since "metanorma", name %>
@@ -20,8 +21,8 @@ WARNING: This repository is for INTERNAL USE ONLY.
 
 <% for name in %w[metanorma-docker] %>
 <%= github_link "metanorma", name %>::
-<%= shield_gha "metanorma", name, "docker-mn" %>
-<%= shield_gha "metanorma", name, "docker-metanorma" %>
+<%= shield_gha "metanorma", name, "build-push" %>
+<%= shield_gha_latest_release "metanorma", name %>
 <%= shield_pull_requests "metanorma", name %>
 <%= shield_commits_since "metanorma", name %>
 <% end %>
@@ -31,6 +32,7 @@ WARNING: This repository is for INTERNAL USE ONLY.
 <%= shield_gha "metanorma", name, "macos" %>
 <%= shield_gha "metanorma", name, "linux" %>
 <%= shield_gha "metanorma", name, "windows" %>
+<%= shield_gha_latest_release "metanorma", name %>
 <%= shield_pull_requests "metanorma", name %>
 <%= shield_commits_since "metanorma", name %>
 <% end %>
@@ -38,6 +40,7 @@ WARNING: This repository is for INTERNAL USE ONLY.
 <% for name in %w[metanorma-snap] %>
 <%= github_link "metanorma", name %>::
 <%= shield_gha "metanorma", name, "main" %>
+<%= shield_gha_latest_release "metanorma", name %>
 <%= shield_pull_requests "metanorma", name %>
 <%= shield_commits_since "metanorma", name %>
 <% end %>
@@ -46,6 +49,7 @@ WARNING: This repository is for INTERNAL USE ONLY.
 <%= github_link "metanorma", name %>::
 <%= shield_gha "metanorma", name, "macos" %>
 <%= shield_gha "metanorma", name, "linux" %>
+<%= shield_gha_latest_release "metanorma", name %>
 <%= shield_pull_requests "metanorma", name %>
 <%= shield_commits_since "metanorma", name %>
 <% end %>
@@ -53,6 +57,7 @@ WARNING: This repository is for INTERNAL USE ONLY.
 <% for name in %w[chocolatey-metanorma] %>
 <%= github_link "metanorma", name %>::
 <%= shield_gha "metanorma", name, "main" %>
+<%= shield_gha_latest_release "metanorma", name %>
 <%= shield_pull_requests "metanorma", name %>
 <%= shield_commits_since "metanorma", name %>
 <% end %>
@@ -78,31 +83,24 @@ WARNING: This repository is for INTERNAL USE ONLY.
 <% for name in %w[metanorma-utils isodoc-i18n iev isoics reverse_adoc metanorma-plugin-lutaml emf2svg-ruby] %>
 <%= github_link "metanorma", name %> <%= shield_gem name %>::
 <%= shield_gha_rake "metanorma", name %>
+<%= shield_gha_latest_release "metanorma", name %>
 <%= shield_code_climate "metanorma", name %>
 <%= shield_pull_requests "metanorma", name %>
 <%= shield_commits_since "metanorma", name %>
 <% end %>
 
-<% for name in %w[mnconvert-ruby] %>
+<% for name in %w[mnconvert-ruby mn2pdf-ruby] %>
 <%= github_link "metanorma", name %>::
-<%= shield_gha "metanorma", name, "mnconvert" %>
-<%= shield_pull_requests "metanorma", name %>
-<%= shield_commits_since "metanorma", name %>
-<% end %>
-
-<% for name in %w[mn2pdf-ruby] %>
-<%= github_link "metanorma", name %>::
-<%= shield_gha "metanorma", name, "mn2pdf" %>
+<%= shield_gha_rake "metanorma", name %>
+<%= shield_gha_latest_release "metanorma", name %>
 <%= shield_pull_requests "metanorma", name %>
 <%= shield_commits_since "metanorma", name %>
 <% end %>
 
 <% for name in %w[mn2pdf mnconvert] %>
 <%= github_link "metanorma", name %> <%= shield_gem name %>::
-<%= shield_gha_macos "metanorma", name %>
-<%= shield_gha_ubuntu "metanorma", name %>
-<%= shield_gha_windows "metanorma", name %>
-<%= shield_code_climate "metanorma", name %>
+<%= shield_gha "metanorma", name, "test" %>
+<%= shield_gha_latest_release "metanorma", name %>
 <%= shield_pull_requests "metanorma", name %>
 <%= shield_commits_since "metanorma", name %>
 <% end %>
@@ -113,6 +111,7 @@ WARNING: This repository is for INTERNAL USE ONLY.
 <% for name in %w[latexmath] %>
 <%= github_link "plurimath", name %> <%= shield_gem name %>::
 <%= shield_gha_test "plurimath", name %>
+<%= shield_gha_latest_release "plurimath", name %>
 <%= shield_code_climate "plurimath", name %>
 <%= shield_pull_requests "plurimath", name %>
 <%= shield_commits_since "plurimath", name %>
@@ -121,6 +120,7 @@ WARNING: This repository is for INTERNAL USE ONLY.
 <% for name in %w[asciimath2unitsml] %>
 <%= github_link "plurimath", name %> <%= shield_gem name %>::
 <%= shield_gha_rake "plurimath", name %>
+<%= shield_gha_latest_release "plurimath", name %>
 <%= shield_code_climate "plurimath", name %>
 <%= shield_pull_requests "plurimath", name %>
 <%= shield_commits_since "plurimath", name %>
@@ -129,6 +129,7 @@ WARNING: This repository is for INTERNAL USE ONLY.
 <% for name in %w[mathml2asciimath omml2mathml unicode2latex] %>
 <%= github_link "plurimath", name %> <%= shield_gem name %>::
 <%= shield_gha_rake "plurimath", name %>
+<%= shield_gha_latest_release "plurimath", name %>
 <%= shield_code_climate "plurimath", name %>
 <%= shield_pull_requests "plurimath", name %>
 <%= shield_commits_since "plurimath", name %>

--- a/erb_helper.rb
+++ b/erb_helper.rb
@@ -114,6 +114,20 @@ def shield_pull_requests(org, repo)
   shield(shield_url, alt: shield_alt_text, link: shield_link)
 end
 
+require 'net/http'
+require 'json'
+
+def shield_gha_latest_release(org, repo, workflow = "rake")
+  release_url = "https://api.github.com/repos/#{org}/#{repo}/releases/latest"
+  tag_name = JSON.parse(Net::HTTP.get(URI(release_url)))["tag_name"]
+
+  shield_url = "https://github.com/#{org}/#{repo}/actions/workflows/#{workflow}.yml/badge.svg?branch=#{tag_name}"
+  shield_link = "https://github.com/#{org}/#{repo}/actions/workflows/#{workflow}.yml?query=branch%3A#{tag_name}"
+  shield_alt_text = "Latest release"
+
+  shield(shield_url, alt: shield_alt_text, link: shield_link)
+end
+
 def shield(img, link:, alt:)
   %Q(image:#{img}["#{alt}",link="#{link}"])
 end

--- a/erb_helper.rb
+++ b/erb_helper.rb
@@ -114,15 +114,16 @@ def shield_pull_requests(org, repo)
   shield(shield_url, alt: shield_alt_text, link: shield_link)
 end
 
-require 'net/http'
-require 'json'
+require "net/http"
+require "json"
 
 def shield_gha_latest_release(org, repo, workflow = "rake")
   release_url = "https://api.github.com/repos/#{org}/#{repo}/releases/latest"
   tag_name = JSON.parse(Net::HTTP.get(URI(release_url)))["tag_name"]
 
-  shield_url = "https://github.com/#{org}/#{repo}/actions/workflows/#{workflow}.yml/badge.svg?branch=#{tag_name}"
-  shield_link = "https://github.com/#{org}/#{repo}/actions/workflows/#{workflow}.yml?query=branch%3A#{tag_name}"
+  base_url = "https://github.com/#{org}/#{repo}/actions/workflows/#{workflow}.yml"
+  shield_url = "#{base_url}/badge.svg?branch=#{tag_name}"
+  shield_link = "#{base_url}?query=branch%3A#{tag_name}"
   shield_alt_text = "Latest release"
 
   shield(shield_url, alt: shield_alt_text, link: shield_link)


### PR DESCRIPTION
Based on:
 - https://github.com/metanorma/metanorma-build-scripts/issues/89

This PR adds an extra badge, which will show CI status for the latest release

Unfortunatelly this badge will not be interactive (because tag_name calculates during README.adoc generation), this is why I added an option to run CI manually (a corn event also can be added).

I have checked other badges service unfortunately didn't found one who can provide such information (latest CI status for specific tag) as a badge, so if you have an idea how to implement it differently I'm open for suggestions