### PR TITLE
Add live GitHub Actions dashboard under docs/gha-dashboard/

### DIFF
--- a/.github/workflows/gha-dashboard-pages.yml
+++ b/.github/workflows/gha-dashboard-pages.yml
@@ -1,0 +1,33 @@
+name: Publish GHA dashboard to Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/gha-dashboard-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/gha-dashboard/README.md
+++ b/docs/gha-dashboard/README.md
@@ -7,7 +7,7 @@ Useful for spotting stuck jobs, coordinating release runs, and getting a quick "
 ## Where to find it
 
 - **Public URL** (after a metanorma org owner enables GitHub Pages on this repo): `https://metanorma.github.io/metanorma-release/gha-dashboard/`
-- **Local** (any clone of this repo): open `docs/gha-dashboard/index.html` in your browser, or run `python3 -m http.server 8000` from the repo root and visit `http://localhost:8000/docs/gha-dashboard/`
+- **Local**, from a clone of this repo: see [Running locally](#running-locally) below.
 
 The Pages URL is the one to share with colleagues — no clone needed.
 
@@ -68,6 +68,59 @@ The per-org page does its work in two distinct steps: first it asks GitHub for t
 **The dashboard is empty / shows "All quiet".** That means there are genuinely no queued or in-progress runs in that org right now. Try triggering a workflow manually (e.g. `gh workflow run` on any repo) and refresh — it should appear.
 
 **Rate-limit warning in the footer.** The authenticated GitHub API budget is 5000 calls per hour per user. A full scan across all five orgs is around 850 calls; you'd need to manually refresh ~5 times per hour to come close. ETag caching on auto-refresh keeps the cost near zero, so this rarely matters in practice.
+
+## Running locally
+
+Useful if the Pages URL isn't published yet (because the metanorma-release Pages source hasn't been enabled, or because you want to test the branch before merge), or if you just want to keep a personal copy that doesn't depend on Ribose infrastructure.
+
+### Prerequisites
+
+- **Git**, any version.
+- **Python 3**, any version that includes the `http.server` module — preinstalled on macOS and on essentially every Linux distribution. Verify with `python3 --version`.
+- A clone of `metanorma/metanorma-release`. If you don't have one yet:
+
+  ```bash
+  git clone https://github.com/metanorma/metanorma-release.git
+  cd metanorma-release
+  ```
+
+### Launching the local web server
+
+From the repo root, in a terminal:
+
+```bash
+python3 -m http.server 8000
+```
+
+That binds a static-file server to port 8000 serving the repo root; you'll see a line like `Serving HTTP on :: port 8000 (http://[::]:8000/) ...`. **Leave the terminal open** — the server runs only as long as that process is alive.
+
+Then open `http://localhost:8000/docs/gha-dashboard/` in your browser. From here, sign-in and usage are identical to the Pages URL.
+
+> **Don't just double-click `index.html` to open it as a `file://` URL.** Browsers block `fetch()` of local files from `file://` origins for security, so `orgs.json` won't load and the dashboard stays blank with no error. Always go through `http://localhost:8000`.
+
+If port 8000 is already in use on your machine (e.g. another dev server), pick anything else:
+
+```bash
+python3 -m http.server 8765
+```
+
+and visit `http://localhost:8765/docs/gha-dashboard/` instead. The port number is just a label; nothing about the dashboard depends on a specific one.
+
+### Stopping the server
+
+In the terminal where it's running, press **`Ctrl-C`**. That sends an interrupt signal, the Python process exits, and the port is freed. You should see the prompt return.
+
+If you backgrounded it (e.g. ran `python3 -m http.server 8000 &` or with `nohup`), find and kill it by port instead:
+
+```bash
+lsof -ti :8000 | xargs kill
+```
+
+Replace `8000` with whatever port you used. `lsof -ti :PORT` prints the PID of whatever owns that port; piping into `kill` terminates it.
+
+### Note on tokens across origins
+
+The PAT in your browser's `localStorage` is scoped per origin. The Pages site (`https://metanorma.github.io`) and your local copy (`http://localhost:8000`) are *different* origins, so a token pasted on one is invisible to the other. You'll be prompted for the token again on first visit to each origin — the same token works in both, just paste it again. Signing out from one origin does not sign you out from the other.
 
 ## Adding a new org
 

--- a/docs/gha-dashboard/README.md
+++ b/docs/gha-dashboard/README.md
@@ -1,0 +1,75 @@
+# Ribose GitHub Actions Dashboard
+
+A live web dashboard showing every GitHub Actions workflow run that is currently **queued** or **in progress** across the orgs we collaborate on: **metanorma**, **relaton**, **lutaml**, **plurimath**, and **claricle**.
+
+Useful for spotting stuck jobs, coordinating release runs, and getting a quick "is CI healthy across the stack?" snapshot.
+
+## Where to find it
+
+- **Public URL** (after a metanorma org owner enables GitHub Pages on this repo): `https://metanorma.github.io/metanorma-release/gha-dashboard/`
+- **Local** (any clone of this repo): open `docs/gha-dashboard/index.html` in your browser, or run `python3 -m http.server 8000` from the repo root and visit `http://localhost:8000/docs/gha-dashboard/`
+
+The Pages URL is the one to share with colleagues — no clone needed.
+
+## First-time setup (~2 minutes)
+
+You'll do this once per browser. The token lives in your browser's local storage; it is never sent anywhere except `api.github.com`.
+
+### 1. Open the dashboard
+
+Click the **Public URL** above (or open it locally — both work the same way). You'll see a sign-in panel asking for a personal access token.
+
+### 2. Create a token on GitHub
+
+Click the **"Create a token on GitHub →"** link in the sign-in panel. It opens `https://github.com/settings/tokens/new` with the right scope and description pre-filled. You only need to:
+
+- Set an **expiration** (90 days is fine; "No expiration" if you don't mind regenerating less often).
+- Scroll down and click **Generate token**.
+- Copy the token that appears (starts with `ghp_…`). It is shown **only once** — if you lose it you'll just generate another.
+
+The scope is **`repo`**, which lets the dashboard see workflow runs in both public repos and the private repos you personally have access to. The token cannot do anything the dashboard does not ask GitHub for: it reads workflow run lists, nothing more, and it lives on your machine only.
+
+### 3. Paste and sign in
+
+Paste the token into the field in the dashboard's sign-in panel and click **Sign in**. After a short verification step you should see five org tiles. Click any of them to see its active runs.
+
+That's it. From now on, opening the dashboard in this browser will skip the sign-in panel and go straight to the org tiles.
+
+## Using the dashboard
+
+- **Entry page** lists the five orgs. Click one to drill in.
+- **Per-org page** shows a table of every workflow run that is queued or in progress. Repos with nothing happening are hidden — you only see things in motion.
+- **Refresh now** re-polls the org immediately.
+- **Auto** dropdown polls every 15, 30, or 60 seconds.
+- **Sort columns** by clicking column headers; default is "longest-running first" so stuck jobs are at the top.
+- **Filter** by repo name, workflow name, and status.
+- **"← All orgs"** in the header returns to the entry page.
+- **Sign out** clears the token from this browser; next visit will ask for a new one.
+
+## FAQ
+
+**Why a PAT and not a one-click GitHub sign-in?** GitHub's OAuth Device Flow endpoints don't accept browser-side cross-origin requests, so the live in-browser fetch architecture has no clean way to use them. PAT-paste was the smallest viable workaround that keeps the dashboard live and self-serve.
+
+**Will the dashboard see my private repos?** Yes — but only the private repos *you yourself* can already see on GitHub.com. The token is per-user; it cannot reach anything you don't have access to.
+
+**Is the token safe to paste?** It is stored only in your browser's `localStorage`, scoped to the dashboard's URL. It is sent only to `api.github.com` (over HTTPS) when the dashboard queries workflow runs. It is never logged, never sent to any third party, never committed to the repo. You can revoke it any time at `https://github.com/settings/tokens`.
+
+**I get "Token rejected by GitHub (401)".** The token is invalid, expired, revoked, or was pasted with extra whitespace. Generate a fresh one and retry.
+
+**The dashboard is empty / shows "All quiet".** That means there are genuinely no queued or in-progress runs in that org right now. Try triggering a workflow manually (e.g. `gh workflow run` on any repo) and refresh — it should appear.
+
+**Rate-limit warning in the footer.** The authenticated GitHub API budget is 5000 calls per hour per user. A full scan across all five orgs is around 850 calls; you'd need to manually refresh ~5 times per hour to come close. ETag caching on auto-refresh keeps the cost near zero, so this rarely matters in practice.
+
+## Adding a new org
+
+If your team works in an org that isn't in the dropdown, open a PR against `docs/gha-dashboard/orgs.json` adding it to the list. The shape is:
+
+```json
+{ "name": "your-org-slug", "label": "Display Name" }
+```
+
+Once merged, the new org tile appears on the entry page automatically.
+
+## Reporting problems
+
+File an issue on this repo (`metanorma/metanorma-release`) and tag whatever happened. The design ticket for the dashboard is [#29](https://github.com/metanorma/metanorma-release/issues/29); architecture context lives there.

--- a/docs/gha-dashboard/README.md
+++ b/docs/gha-dashboard/README.md
@@ -37,7 +37,7 @@ That's it. From now on, opening the dashboard in this browser will skip the sign
 
 ## Using the dashboard
 
-- **Entry page** lists the five orgs. Click one to drill in.
+- **Entry page** lists the orgs you're subscribed to. Click one to drill in. Use the **"Manage subscriptions"** panel at the bottom of the entry page to hide orgs you don't care about; new orgs added to `orgs.json` later will appear automatically (subscribed by default). The choice is per-browser, stored in your local storage; it doesn't affect anyone else.
 - **Per-org page** shows a table of every workflow run that is queued or in progress in *that one org*. Repos with nothing happening are hidden — you only see things in motion.
 
 ### The three refresh controls

--- a/docs/gha-dashboard/README.md
+++ b/docs/gha-dashboard/README.md
@@ -38,11 +38,20 @@ That's it. From now on, opening the dashboard in this browser will skip the sign
 ## Using the dashboard
 
 - **Entry page** lists the five orgs. Click one to drill in.
-- **Per-org page** shows a table of every workflow run that is queued or in progress. Repos with nothing happening are hidden — you only see things in motion.
-- **Refresh now** re-polls the org immediately.
-- **Auto** dropdown polls every 15, 30, or 60 seconds.
+- **Per-org page** shows a table of every workflow run that is queued or in progress in *that one org*. Repos with nothing happening are hidden — you only see things in motion.
+
+### The three refresh controls
+
+The per-org page does its work in two distinct steps: first it asks GitHub for the **list of repos in the org** (the "repo list"), then for each repo it asks GitHub which workflow runs are currently **queued or in progress** (the "run list"). The repo list is cached for the rest of the browser session because orgs rarely add/remove repos mid-session, and re-fetching ~80 repos every poll would be wasteful. The three refresh controls hit different combinations of these two steps:
+
+- **Refresh now** — re-fetches just the *run list* for every cached repo. Use this when you want a current-state snapshot, e.g. "did that job finish yet?" / "has the queue cleared?". This is the cheap-and-frequent refresh.
+- **Auto (off / 15s / 30s / 60s)** — does exactly the same thing as "Refresh now" automatically on a timer. Off by default. ETag conditional caching means each repeat poll is near-free against the GitHub API rate limit when nothing has changed.
+- **Rescan org** — re-fetches the *repo list* from GitHub, then refreshes the runs. Use this when a repo has been **added to, removed from, renamed in, archived in, or unarchived in** the org since you opened the dashboard. Normal "Refresh now" / "Auto" cycles will NOT pick up such changes because they reuse the cached repo list. Rarely needed in a single sitting.
+
+### Other controls
+
 - **Sort columns** by clicking column headers; default is "longest-running first" so stuck jobs are at the top.
-- **Filter** by repo name, workflow name, and status.
+- **Filter** by repo name, workflow name, and status (in-progress / queued).
 - **"← All orgs"** in the header returns to the entry page.
 - **Sign out** clears the token from this browser; next visit will ask for a new one.
 

--- a/docs/gha-dashboard/actions-dashboard.html
+++ b/docs/gha-dashboard/actions-dashboard.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Active runs</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body class="dashboard">
+  <header class="page-header">
+    <div class="page-header-row">
+      <div class="page-header-left">
+        <a class="back-link" href="./index.html">&larr; All orgs</a>
+        <h1 id="org-title">Active runs</h1>
+      </div>
+      <div id="auth-header" class="auth-header"></div>
+    </div>
+    <div class="controls">
+      <span id="status" class="status-text"></span>
+      <button type="button" id="refresh-now">Refresh now</button>
+      <label class="control-label">
+        Auto:
+        <select id="auto-refresh">
+          <option value="off" selected>off</option>
+          <option value="15s">15s</option>
+          <option value="30s">30s</option>
+          <option value="60s">60s</option>
+        </select>
+      </label>
+      <button type="button" id="rescan-org">Rescan org</button>
+      <span id="rate-limit" class="rate-limit"></span>
+    </div>
+    <div class="filter-bar">
+      <input type="search" id="filter-text" placeholder="Filter repo / workflow…">
+      <label class="control-label"><input type="checkbox" id="filter-in-progress" checked> in-progress</label>
+      <label class="control-label"><input type="checkbox" id="filter-queued" checked> queued</label>
+      <span id="active-count" class="active-count"></span>
+    </div>
+  </header>
+  <main>
+    <table id="runs">
+      <thead>
+        <tr>
+          <th data-sort="repo">Repo</th>
+          <th data-sort="workflow">Workflow</th>
+          <th>Run</th>
+          <th data-sort="ref">Branch / PR</th>
+          <th data-sort="event">Event</th>
+          <th data-sort="actor">Actor</th>
+          <th data-sort="status">Status</th>
+          <th data-sort="started">Started</th>
+          <th data-sort="elapsed">Elapsed</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <div id="empty-state" class="empty-state" style="display: none">
+      <p>All quiet.</p>
+      <p class="empty-count"><span id="empty-count"></span>.</p>
+    </div>
+  </main>
+  <script type="module" src="./dashboard.js"></script>
+</body>
+</html>

--- a/docs/gha-dashboard/auth.js
+++ b/docs/gha-dashboard/auth.js
@@ -1,0 +1,148 @@
+// OAuth Device Flow auth for the metanorma & friends Actions dashboard.
+// Register the OAuth App on the @opoudjis personal account with Device Flow
+// enabled, then paste its Client ID below.
+export const CLIENT_ID = "REPLACE_WITH_OAUTH_APP_CLIENT_ID";
+
+const TOKEN_KEY = "metanorma-actions-dashboard.token";
+const USER_KEY = "metanorma-actions-dashboard.user";
+
+const DEVICE_CODE_URL = "https://github.com/login/device/code";
+const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const VERIFICATION_URI = "https://github.com/login/device";
+
+export function getToken() {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function getCachedUser() {
+  const raw = localStorage.getItem(USER_KEY);
+  return raw ? JSON.parse(raw) : null;
+}
+
+export function signOut() {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USER_KEY);
+}
+
+export async function ensureAuthenticated() {
+  let token = getToken();
+  if (token) return token;
+  token = await runDeviceFlow();
+  localStorage.setItem(TOKEN_KEY, token);
+  const user = await fetchUser(token);
+  localStorage.setItem(USER_KEY, JSON.stringify(user));
+  return token;
+}
+
+async function fetchUser(token) {
+  const res = await fetch("https://api.github.com/user", {
+    headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) throw new Error(`GET /user failed: ${res.status}`);
+  const body = await res.json();
+  return { login: body.login, avatar_url: body.avatar_url };
+}
+
+async function runDeviceFlow() {
+  if (CLIENT_ID === "REPLACE_WITH_OAUTH_APP_CLIENT_ID") {
+    throw new Error(
+      "OAuth Client ID not configured. Edit docs/gha-dashboard/auth.js and set CLIENT_ID.",
+    );
+  }
+  const start = await postForm(DEVICE_CODE_URL, { client_id: CLIENT_ID, scope: "" });
+  const { device_code, user_code, verification_uri, interval, expires_in } = start;
+  const deadline = Date.now() + expires_in * 1000;
+  const dismissed = renderDeviceModal({ user_code, verification_uri: verification_uri || VERIFICATION_URI });
+  let pollInterval = (interval || 5) * 1000;
+  while (Date.now() < deadline) {
+    if (dismissed.cancelled) throw new Error("Sign-in cancelled.");
+    await sleep(pollInterval);
+    const tokenRes = await postForm(ACCESS_TOKEN_URL, {
+      client_id: CLIENT_ID,
+      device_code,
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    });
+    if (tokenRes.access_token) {
+      dismissModal();
+      return tokenRes.access_token;
+    }
+    if (tokenRes.error === "authorization_pending") continue;
+    if (tokenRes.error === "slow_down") {
+      pollInterval += 5000;
+      continue;
+    }
+    if (tokenRes.error === "expired_token" || tokenRes.error === "access_denied") {
+      dismissModal();
+      throw new Error(`Sign-in failed: ${tokenRes.error}`);
+    }
+    throw new Error(`Unexpected token response: ${JSON.stringify(tokenRes)}`);
+  }
+  dismissModal();
+  throw new Error("Device code expired before sign-in completed.");
+}
+
+async function postForm(url, params) {
+  const body = new URLSearchParams(params).toString();
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { Accept: "application/json", "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  if (!res.ok) throw new Error(`POST ${url} failed: ${res.status}`);
+  return res.json();
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function renderDeviceModal({ user_code, verification_uri }) {
+  const state = { cancelled: false };
+  const overlay = document.createElement("div");
+  overlay.id = "device-flow-modal";
+  overlay.innerHTML = `
+    <div class="device-flow-card">
+      <h2>Sign in to GitHub</h2>
+      <p>Open <a href="${verification_uri}" target="_blank" rel="noopener">${verification_uri}</a> and enter the code:</p>
+      <div class="device-flow-code">${user_code}</div>
+      <button type="button" class="device-flow-open">Copy code &amp; open GitHub</button>
+      <button type="button" class="device-flow-cancel">Cancel</button>
+      <p class="device-flow-hint">This page will continue automatically once you complete consent.</p>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+  overlay.querySelector(".device-flow-open").addEventListener("click", async () => {
+    try {
+      await navigator.clipboard.writeText(user_code);
+    } catch (_) {}
+    window.open(verification_uri, "_blank", "noopener");
+  });
+  overlay.querySelector(".device-flow-cancel").addEventListener("click", () => {
+    state.cancelled = true;
+    dismissModal();
+  });
+  return state;
+}
+
+function dismissModal() {
+  const overlay = document.getElementById("device-flow-modal");
+  if (overlay) overlay.remove();
+}
+
+export function renderAuthHeader(container, { onSignOut } = {}) {
+  const user = getCachedUser();
+  if (!user) {
+    container.innerHTML = `<span class="auth-pending">Signing in&hellip;</span>`;
+    return;
+  }
+  container.innerHTML = `
+    <img class="auth-avatar" src="${user.avatar_url}" alt="" width="20" height="20">
+    <span class="auth-login">@${user.login}</span>
+    <button type="button" class="auth-signout">Sign out</button>
+  `;
+  container.querySelector(".auth-signout").addEventListener("click", () => {
+    signOut();
+    if (onSignOut) onSignOut();
+    else location.reload();
+  });
+}

--- a/docs/gha-dashboard/auth.js
+++ b/docs/gha-dashboard/auth.js
@@ -7,7 +7,7 @@
 const TOKEN_KEY = "metanorma-actions-dashboard.token";
 const USER_KEY = "metanorma-actions-dashboard.user";
 const TOKEN_NEW_URL =
-  "https://github.com/settings/tokens/new?description=Ribose%20GitHub%20Actions%20Dashboard";
+  "https://github.com/settings/tokens/new?description=Ribose%20GitHub%20Actions%20Dashboard&scopes=repo";
 
 export function getToken() {
   return localStorage.getItem(TOKEN_KEY);
@@ -36,8 +36,8 @@ function runPatPrompt() {
     overlay.innerHTML = `
       <div class="pat-card">
         <h2>Sign in with a GitHub token</h2>
-        <p>Paste a <strong>personal access token</strong>. The dashboard only needs authentication to lift the GitHub API rate limit &mdash; <em>no scopes are required</em> for public-repo access.</p>
-        <p><a href="${TOKEN_NEW_URL}" target="_blank" rel="noopener">Create a token on GitHub &rarr;</a></p>
+        <p>Paste a <strong>personal access token</strong> with the <code>repo</code> scope. The dashboard uses it to list workflow runs across every repo you have access to &mdash; public and private &mdash; in the configured orgs.</p>
+        <p><a href="${TOKEN_NEW_URL}" target="_blank" rel="noopener">Create a token on GitHub &rarr;</a> (the link pre-selects the <code>repo</code> scope).</p>
         <input type="password" class="pat-input" placeholder="ghp_&hellip; or github_pat_&hellip;" autocomplete="off" spellcheck="false">
         <button type="button" class="pat-submit">Sign in</button>
         <p class="pat-error" hidden></p>

--- a/docs/gha-dashboard/auth.js
+++ b/docs/gha-dashboard/auth.js
@@ -1,14 +1,13 @@
-// OAuth Device Flow auth for the Ribose GitHub Actions Dashboard.
-// Client ID is the public OAuth App identifier; safe to commit. The app is
-// registered under @opoudjis with Device Flow enabled.
-export const CLIENT_ID = "Ov23ctdTo73CKizaGSuv";
+// Personal Access Token auth for the Ribose GitHub Actions Dashboard.
+// Browser-side OAuth Device Flow was abandoned because GitHub's
+// /login/device/code does not support cross-origin CORS from arbitrary
+// browser origins (verified empirically; see issue #29). api.github.com
+// itself supports CORS, so once the user pastes a PAT the rest works.
 
 const TOKEN_KEY = "metanorma-actions-dashboard.token";
 const USER_KEY = "metanorma-actions-dashboard.user";
-
-const DEVICE_CODE_URL = "https://github.com/login/device/code";
-const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
-const VERIFICATION_URI = "https://github.com/login/device";
+const TOKEN_NEW_URL =
+  "https://github.com/settings/tokens/new?description=Ribose%20GitHub%20Actions%20Dashboard";
 
 export function getToken() {
   return localStorage.getItem(TOKEN_KEY);
@@ -25,108 +24,73 @@ export function signOut() {
 }
 
 export async function ensureAuthenticated() {
-  let token = getToken();
-  if (token) return token;
-  token = await runDeviceFlow();
-  localStorage.setItem(TOKEN_KEY, token);
-  const user = await fetchUser(token);
-  localStorage.setItem(USER_KEY, JSON.stringify(user));
-  return token;
+  const existing = getToken();
+  if (existing) return existing;
+  return runPatPrompt();
+}
+
+function runPatPrompt() {
+  return new Promise((resolve) => {
+    const overlay = document.createElement("div");
+    overlay.id = "pat-modal";
+    overlay.innerHTML = `
+      <div class="pat-card">
+        <h2>Sign in with a GitHub token</h2>
+        <p>Paste a <strong>personal access token</strong>. The dashboard only needs authentication to lift the GitHub API rate limit &mdash; <em>no scopes are required</em> for public-repo access.</p>
+        <p><a href="${TOKEN_NEW_URL}" target="_blank" rel="noopener">Create a token on GitHub &rarr;</a></p>
+        <input type="password" class="pat-input" placeholder="ghp_&hellip; or github_pat_&hellip;" autocomplete="off" spellcheck="false">
+        <button type="button" class="pat-submit">Sign in</button>
+        <p class="pat-error" hidden></p>
+        <p class="pat-hint">Stored in this browser's <code>localStorage</code>; only sent to <code>api.github.com</code>.</p>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+    const input = overlay.querySelector(".pat-input");
+    const submit = overlay.querySelector(".pat-submit");
+    const error = overlay.querySelector(".pat-error");
+    input.focus();
+
+    const trySubmit = async () => {
+      const token = input.value.trim();
+      if (!token) return;
+      submit.disabled = true;
+      submit.textContent = "Verifying…";
+      error.hidden = true;
+      try {
+        const user = await fetchUser(token);
+        localStorage.setItem(TOKEN_KEY, token);
+        localStorage.setItem(USER_KEY, JSON.stringify(user));
+        overlay.remove();
+        resolve(token);
+      } catch (e) {
+        submit.disabled = false;
+        submit.textContent = "Sign in";
+        error.textContent = e.message;
+        error.hidden = false;
+        input.focus();
+        input.select();
+      }
+    };
+    submit.addEventListener("click", trySubmit);
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") trySubmit();
+    });
+  });
 }
 
 async function fetchUser(token) {
-  const res = await fetch("https://api.github.com/user", {
-    headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" },
-  });
+  let res;
+  try {
+    res = await fetch("https://api.github.com/user", {
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" },
+    });
+  } catch (_) {
+    throw new Error("Network error reaching api.github.com.");
+  }
+  if (res.status === 401) throw new Error("Token rejected by GitHub (401). Double-check it.");
   if (!res.ok) throw new Error(`GET /user failed: ${res.status}`);
   const body = await res.json();
   return { login: body.login, avatar_url: body.avatar_url };
-}
-
-async function runDeviceFlow() {
-  if (CLIENT_ID === "REPLACE_WITH_OAUTH_APP_CLIENT_ID") {
-    throw new Error(
-      "OAuth Client ID not configured. Edit docs/gha-dashboard/auth.js and set CLIENT_ID.",
-    );
-  }
-  const start = await postForm(DEVICE_CODE_URL, { client_id: CLIENT_ID, scope: "" });
-  const { device_code, user_code, verification_uri, interval, expires_in } = start;
-  const deadline = Date.now() + expires_in * 1000;
-  const dismissed = renderDeviceModal({ user_code, verification_uri: verification_uri || VERIFICATION_URI });
-  let pollInterval = (interval || 5) * 1000;
-  while (Date.now() < deadline) {
-    if (dismissed.cancelled) throw new Error("Sign-in cancelled.");
-    await sleep(pollInterval);
-    const tokenRes = await postForm(ACCESS_TOKEN_URL, {
-      client_id: CLIENT_ID,
-      device_code,
-      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-    });
-    if (tokenRes.access_token) {
-      dismissModal();
-      return tokenRes.access_token;
-    }
-    if (tokenRes.error === "authorization_pending") continue;
-    if (tokenRes.error === "slow_down") {
-      pollInterval += 5000;
-      continue;
-    }
-    if (tokenRes.error === "expired_token" || tokenRes.error === "access_denied") {
-      dismissModal();
-      throw new Error(`Sign-in failed: ${tokenRes.error}`);
-    }
-    throw new Error(`Unexpected token response: ${JSON.stringify(tokenRes)}`);
-  }
-  dismissModal();
-  throw new Error("Device code expired before sign-in completed.");
-}
-
-async function postForm(url, params) {
-  const body = new URLSearchParams(params).toString();
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { Accept: "application/json", "Content-Type": "application/x-www-form-urlencoded" },
-    body,
-  });
-  if (!res.ok) throw new Error(`POST ${url} failed: ${res.status}`);
-  return res.json();
-}
-
-function sleep(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
-function renderDeviceModal({ user_code, verification_uri }) {
-  const state = { cancelled: false };
-  const overlay = document.createElement("div");
-  overlay.id = "device-flow-modal";
-  overlay.innerHTML = `
-    <div class="device-flow-card">
-      <h2>Sign in to GitHub</h2>
-      <p>Open <a href="${verification_uri}" target="_blank" rel="noopener">${verification_uri}</a> and enter the code:</p>
-      <div class="device-flow-code">${user_code}</div>
-      <button type="button" class="device-flow-open">Copy code &amp; open GitHub</button>
-      <button type="button" class="device-flow-cancel">Cancel</button>
-      <p class="device-flow-hint">This page will continue automatically once you complete consent.</p>
-    </div>
-  `;
-  document.body.appendChild(overlay);
-  overlay.querySelector(".device-flow-open").addEventListener("click", async () => {
-    try {
-      await navigator.clipboard.writeText(user_code);
-    } catch (_) {}
-    window.open(verification_uri, "_blank", "noopener");
-  });
-  overlay.querySelector(".device-flow-cancel").addEventListener("click", () => {
-    state.cancelled = true;
-    dismissModal();
-  });
-  return state;
-}
-
-function dismissModal() {
-  const overlay = document.getElementById("device-flow-modal");
-  if (overlay) overlay.remove();
 }
 
 export function renderAuthHeader(container, { onSignOut } = {}) {

--- a/docs/gha-dashboard/auth.js
+++ b/docs/gha-dashboard/auth.js
@@ -1,7 +1,7 @@
-// OAuth Device Flow auth for the metanorma & friends Actions dashboard.
-// Register the OAuth App on the @opoudjis personal account with Device Flow
-// enabled, then paste its Client ID below.
-export const CLIENT_ID = "REPLACE_WITH_OAUTH_APP_CLIENT_ID";
+// OAuth Device Flow auth for the Ribose GitHub Actions Dashboard.
+// Client ID is the public OAuth App identifier; safe to commit. The app is
+// registered under @opoudjis with Device Flow enabled.
+export const CLIENT_ID = "Ov23ctdTo73CKizaGSuv";
 
 const TOKEN_KEY = "metanorma-actions-dashboard.token";
 const USER_KEY = "metanorma-actions-dashboard.user";

--- a/docs/gha-dashboard/dashboard.js
+++ b/docs/gha-dashboard/dashboard.js
@@ -89,7 +89,7 @@ async function initialLoad() {
 async function fetchOrgRepos(org) {
   const token = getToken();
   const repos = [];
-  let url = `https://api.github.com/orgs/${org}/repos?per_page=100&type=public`;
+  let url = `https://api.github.com/orgs/${org}/repos?per_page=100&type=all`;
   while (url) {
     const res = await fetch(url, {
       headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" },

--- a/docs/gha-dashboard/dashboard.js
+++ b/docs/gha-dashboard/dashboard.js
@@ -1,0 +1,355 @@
+import { ensureAuthenticated, getToken, renderAuthHeader } from "./auth.js";
+
+const REPO_CACHE_PREFIX = "metanorma-actions-dashboard.repos.";
+const ETAG_CACHE_PREFIX = "metanorma-actions-dashboard.etag.";
+const STATUSES = ["in_progress", "queued"];
+const CONCURRENCY = 8;
+const REFRESH_INTERVALS = { off: 0, "15s": 15000, "30s": 30000, "60s": 60000 };
+
+const state = {
+  org: null,
+  repos: [],
+  rows: [],
+  sort: { key: "elapsed", dir: "desc" },
+  filter: { text: "", in_progress: true, queued: true },
+  rateLimit: { remaining: null, limit: null, reset: null },
+  autoRefreshTimer: null,
+  // ETag bodies: { [`${org}/${repo}/${status}`]: { etag, runs } }
+  etagBodies: new Map(),
+};
+
+async function main() {
+  const params = new URLSearchParams(location.search);
+  const org = params.get("org");
+  if (!org) return showError("Missing ?org= parameter.");
+
+  const allowed = await loadAllowedOrgs();
+  if (!allowed.includes(org)) {
+    return showError(
+      `Unknown org "${org}". Edit docs/gha-dashboard/orgs.json to add it.`,
+    );
+  }
+  state.org = org;
+  document.title = `${org} — active runs`;
+  document.getElementById("org-title").textContent = `${org} — active runs`;
+
+  await ensureAuthenticated();
+  renderAuthHeader(document.getElementById("auth-header"));
+
+  wireControls();
+  await initialLoad();
+}
+
+async function loadAllowedOrgs() {
+  const res = await fetch("./orgs.json", { cache: "no-cache" });
+  const body = await res.json();
+  return body.orgs.map((o) => o.name);
+}
+
+function wireControls() {
+  document.getElementById("refresh-now").addEventListener("click", () => poll());
+  document.getElementById("rescan-org").addEventListener("click", () => initialLoad());
+  document.getElementById("auto-refresh").addEventListener("change", (e) => setAutoRefresh(e.target.value));
+  const filterText = document.getElementById("filter-text");
+  filterText.addEventListener("input", (e) => {
+    state.filter.text = e.target.value.toLowerCase();
+    renderTable();
+  });
+  document.getElementById("filter-in-progress").addEventListener("change", (e) => {
+    state.filter.in_progress = e.target.checked;
+    renderTable();
+  });
+  document.getElementById("filter-queued").addEventListener("change", (e) => {
+    state.filter.queued = e.target.checked;
+    renderTable();
+  });
+  document.querySelectorAll("th[data-sort]").forEach((th) => {
+    th.addEventListener("click", () => {
+      const key = th.dataset.sort;
+      if (state.sort.key === key) state.sort.dir = state.sort.dir === "asc" ? "desc" : "asc";
+      else state.sort = { key, dir: key === "elapsed" || key === "started" ? "desc" : "asc" };
+      renderTable();
+    });
+  });
+  setInterval(tickElapsed, 1000);
+}
+
+async function initialLoad() {
+  setStatus("Loading repo list…");
+  state.etagBodies = new Map();
+  try {
+    state.repos = await fetchOrgRepos(state.org);
+    sessionStorage.setItem(REPO_CACHE_PREFIX + state.org, JSON.stringify(state.repos));
+  } catch (err) {
+    return showError(`Failed to enumerate repos in ${state.org}: ${err.message}`);
+  }
+  await poll();
+}
+
+async function fetchOrgRepos(org) {
+  const token = getToken();
+  const repos = [];
+  let url = `https://api.github.com/orgs/${org}/repos?per_page=100&type=public`;
+  while (url) {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" },
+    });
+    updateRateLimit(res);
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const page = await res.json();
+    for (const r of page) {
+      if (r.archived || r.disabled) continue;
+      repos.push({ name: r.name, html_url: r.html_url });
+    }
+    url = parseNextLink(res.headers.get("Link"));
+  }
+  return repos;
+}
+
+function parseNextLink(header) {
+  if (!header) return null;
+  for (const part of header.split(",")) {
+    const m = part.match(/<([^>]+)>;\s*rel="next"/);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+async function poll() {
+  if (!state.repos.length) return;
+  setStatus(`Polling ${state.repos.length} ${state.org} repos…`);
+  const tasks = [];
+  for (const repo of state.repos) {
+    for (const status of STATUSES) {
+      tasks.push({ repo, status });
+    }
+  }
+  const results = await parallelLimit(tasks, CONCURRENCY, async ({ repo, status }) => {
+    return fetchRunsForRepo(state.org, repo.name, status);
+  });
+  const rows = [];
+  for (let i = 0; i < tasks.length; i++) {
+    const { repo, status } = tasks[i];
+    const runs = results[i];
+    if (!runs) continue;
+    for (const run of runs) {
+      rows.push(rowFromRun(repo, run, status));
+    }
+  }
+  state.rows = rows;
+  setStatus(`Refreshed ${new Date().toLocaleTimeString()}`);
+  renderTable();
+}
+
+async function fetchRunsForRepo(org, repo, status) {
+  const token = getToken();
+  const url = `https://api.github.com/repos/${org}/${repo}/actions/runs?status=${status}&per_page=30`;
+  const cacheKey = `${org}/${repo}/${status}`;
+  const cached = state.etagBodies.get(cacheKey);
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+  };
+  if (cached) headers["If-None-Match"] = cached.etag;
+  let res;
+  try {
+    res = await fetch(url, { headers });
+  } catch (_) {
+    return cached ? cached.runs : [];
+  }
+  updateRateLimit(res);
+  if (res.status === 304 && cached) return cached.runs;
+  if (!res.ok) return cached ? cached.runs : [];
+  const etag = res.headers.get("ETag");
+  const body = await res.json();
+  const runs = body.workflow_runs || [];
+  if (etag) state.etagBodies.set(cacheKey, { etag, runs });
+  return runs;
+}
+
+function rowFromRun(repo, run, status) {
+  const isPR = run.event === "pull_request" && run.pull_requests && run.pull_requests.length;
+  const ref = isPR ? `PR #${run.pull_requests[0].number}` : run.head_branch || run.head_sha.slice(0, 7);
+  return {
+    repo: repo.name,
+    repo_url: repo.html_url,
+    workflow: run.name || run.path,
+    workflow_url: `${repo.html_url}/actions/workflows/${pathToFile(run.path)}`,
+    run_number: run.run_number,
+    run_url: run.html_url,
+    ref,
+    ref_url: isPR
+      ? run.pull_requests[0].url.replace("api.github.com/repos", "github.com").replace("/pulls/", "/pull/")
+      : `${repo.html_url}/tree/${encodeURIComponent(run.head_branch || run.head_sha)}`,
+    event: run.event,
+    actor: run.actor ? { login: run.actor.login, avatar_url: run.actor.avatar_url, html_url: run.actor.html_url } : null,
+    status,
+    started_at: run.run_started_at || run.created_at,
+  };
+}
+
+function pathToFile(p) {
+  if (!p) return "";
+  const slash = p.lastIndexOf("/");
+  return slash >= 0 ? p.slice(slash + 1) : p;
+}
+
+async function parallelLimit(items, limit, worker) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      try {
+        results[i] = await worker(items[i]);
+      } catch (_) {
+        results[i] = null;
+      }
+    }
+  });
+  await Promise.all(runners);
+  return results;
+}
+
+function updateRateLimit(res) {
+  const remaining = res.headers.get("X-RateLimit-Remaining");
+  const limit = res.headers.get("X-RateLimit-Limit");
+  const reset = res.headers.get("X-RateLimit-Reset");
+  if (remaining !== null) state.rateLimit.remaining = parseInt(remaining, 10);
+  if (limit !== null) state.rateLimit.limit = parseInt(limit, 10);
+  if (reset !== null) state.rateLimit.reset = parseInt(reset, 10);
+  renderRateLimit();
+}
+
+function renderRateLimit() {
+  const el = document.getElementById("rate-limit");
+  if (state.rateLimit.remaining === null) {
+    el.textContent = "";
+    return;
+  }
+  const resetsIn = state.rateLimit.reset ? Math.max(0, Math.round((state.rateLimit.reset * 1000 - Date.now()) / 60000)) : null;
+  const resetStr = resetsIn !== null ? ` — resets in ${resetsIn}m` : "";
+  el.textContent = `Rate-limit: ${state.rateLimit.remaining} / ${state.rateLimit.limit}${resetStr}`;
+}
+
+function renderTable() {
+  const visible = state.rows.filter((r) => {
+    if (r.status === "in_progress" && !state.filter.in_progress) return false;
+    if (r.status === "queued" && !state.filter.queued) return false;
+    if (state.filter.text) {
+      const hay = `${r.repo} ${r.workflow}`.toLowerCase();
+      if (!hay.includes(state.filter.text)) return false;
+    }
+    return true;
+  });
+  visible.sort(comparator(state.sort));
+
+  const activeRepos = new Set(visible.map((r) => r.repo));
+  const totalRepos = state.repos.length;
+
+  const tbody = document.querySelector("#runs tbody");
+  if (visible.length === 0) {
+    tbody.innerHTML = "";
+    document.getElementById("empty-state").style.display = "block";
+    document.getElementById("empty-count").textContent = `0 active runs across ${totalRepos} ${state.org} repos`;
+    return;
+  }
+  document.getElementById("empty-state").style.display = "none";
+  tbody.innerHTML = visible.map(renderRow).join("");
+  document.getElementById("active-count").textContent =
+    `${visible.length} active runs across ${activeRepos.size} of ${totalRepos} ${state.org} repos`;
+}
+
+function comparator({ key, dir }) {
+  const mul = dir === "asc" ? 1 : -1;
+  return (a, b) => {
+    let av, bv;
+    switch (key) {
+      case "repo": av = a.repo; bv = b.repo; break;
+      case "workflow": av = a.workflow; bv = b.workflow; break;
+      case "ref": av = a.ref; bv = b.ref; break;
+      case "event": av = a.event; bv = b.event; break;
+      case "status": av = a.status; bv = b.status; break;
+      case "actor": av = a.actor ? a.actor.login : ""; bv = b.actor ? b.actor.login : ""; break;
+      case "started":
+      case "elapsed":
+      default:
+        av = new Date(a.started_at).getTime();
+        bv = new Date(b.started_at).getTime();
+        // elapsed-desc == started-asc semantically; flip when key is elapsed
+        if (key === "elapsed") return (av - bv) * -mul;
+        return (av - bv) * mul;
+    }
+    return av.localeCompare(bv) * mul;
+  };
+}
+
+function renderRow(r) {
+  const elapsed = r.status === "in_progress" ? formatElapsed(r.started_at) : "—";
+  const actorCell = r.actor
+    ? `<a href="${r.actor.html_url}" target="_blank" rel="noopener"><img class="actor-avatar" src="${r.actor.avatar_url}" alt="" width="16" height="16"> ${escapeHtml(r.actor.login)}</a>`
+    : "";
+  return `
+    <tr>
+      <td><a href="${r.repo_url}" target="_blank" rel="noopener">${escapeHtml(r.repo)}</a></td>
+      <td><a href="${r.workflow_url}" target="_blank" rel="noopener">${escapeHtml(r.workflow || "")}</a></td>
+      <td><a href="${r.run_url}" target="_blank" rel="noopener">#${r.run_number}</a></td>
+      <td><a href="${r.ref_url}" target="_blank" rel="noopener">${escapeHtml(r.ref || "")}</a></td>
+      <td>${escapeHtml(r.event)}</td>
+      <td>${actorCell}</td>
+      <td><span class="status status-${r.status}">${r.status === "in_progress" ? "running" : "queued"}</span></td>
+      <td>${formatRelative(r.started_at)}</td>
+      <td class="elapsed" data-started="${r.started_at}" data-status="${r.status}">${elapsed}</td>
+    </tr>
+  `;
+}
+
+function formatRelative(iso) {
+  const t = new Date(iso).getTime();
+  const diff = Date.now() - t;
+  if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`;
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  return `${Math.floor(diff / 3_600_000)}h ago`;
+}
+
+function formatElapsed(iso) {
+  const diff = Math.max(0, Date.now() - new Date(iso).getTime());
+  const mm = Math.floor(diff / 60_000);
+  const ss = Math.floor((diff % 60_000) / 1000);
+  return `${String(mm).padStart(2, "0")}:${String(ss).padStart(2, "0")}`;
+}
+
+function tickElapsed() {
+  for (const cell of document.querySelectorAll(".elapsed")) {
+    if (cell.dataset.status !== "in_progress") continue;
+    cell.textContent = formatElapsed(cell.dataset.started);
+  }
+  renderRateLimit();
+}
+
+function setStatus(msg) {
+  document.getElementById("status").textContent = msg;
+}
+
+function showError(msg) {
+  document.getElementById("status").textContent = "";
+  const main = document.querySelector("main");
+  main.innerHTML = `<div class="error">${escapeHtml(msg)} <a href="./index.html">← All orgs</a></div>`;
+}
+
+function setAutoRefresh(value) {
+  if (state.autoRefreshTimer) {
+    clearInterval(state.autoRefreshTimer);
+    state.autoRefreshTimer = null;
+  }
+  const ms = REFRESH_INTERVALS[value] || 0;
+  if (ms > 0) state.autoRefreshTimer = setInterval(() => poll(), ms);
+}
+
+function escapeHtml(s) {
+  if (s == null) return "";
+  return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+main().catch((err) => showError(err.message));

--- a/docs/gha-dashboard/entry.js
+++ b/docs/gha-dashboard/entry.js
@@ -1,0 +1,86 @@
+import { ensureAuthenticated, getToken, renderAuthHeader } from "./auth.js";
+
+const ORG_AVATAR_CACHE = "metanorma-actions-dashboard.orgAvatars";
+
+async function main() {
+  await ensureAuthenticated();
+  renderAuthHeader(document.getElementById("auth-header"));
+  const orgs = await loadOrgs();
+  renderTiles(orgs);
+  hydrateAvatars(orgs);
+}
+
+async function loadOrgs() {
+  const res = await fetch("./orgs.json", { cache: "no-cache" });
+  if (!res.ok) throw new Error(`Failed to load orgs.json: ${res.status}`);
+  const body = await res.json();
+  return body.orgs;
+}
+
+function renderTiles(orgs) {
+  const grid = document.getElementById("org-grid");
+  const cached = readAvatarCache();
+  grid.innerHTML = orgs
+    .map((org) => {
+      const avatar = cached[org.name];
+      const img = avatar
+        ? `<img class="org-avatar" src="${avatar}" alt="" width="64" height="64">`
+        : `<div class="org-avatar-placeholder" data-org="${org.name}"></div>`;
+      return `
+        <a class="org-tile" href="./actions-dashboard.html?org=${encodeURIComponent(org.name)}">
+          ${img}
+          <span class="org-label">${escapeHtml(org.label)}</span>
+          <span class="org-name">${escapeHtml(org.name)}</span>
+        </a>
+      `;
+    })
+    .join("");
+}
+
+async function hydrateAvatars(orgs) {
+  const token = getToken();
+  const cached = readAvatarCache();
+  let updated = false;
+  for (const org of orgs) {
+    if (cached[org.name]) continue;
+    try {
+      const res = await fetch(`https://api.github.com/orgs/${org.name}`, {
+        headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" },
+      });
+      if (!res.ok) continue;
+      const body = await res.json();
+      cached[org.name] = body.avatar_url;
+      updated = true;
+      const placeholder = document.querySelector(`.org-avatar-placeholder[data-org="${org.name}"]`);
+      if (placeholder) {
+        const img = document.createElement("img");
+        img.className = "org-avatar";
+        img.src = body.avatar_url;
+        img.alt = "";
+        img.width = 64;
+        img.height = 64;
+        placeholder.replaceWith(img);
+      }
+    } catch (_) {
+      // best-effort
+    }
+  }
+  if (updated) localStorage.setItem(ORG_AVATAR_CACHE, JSON.stringify(cached));
+}
+
+function readAvatarCache() {
+  try {
+    return JSON.parse(localStorage.getItem(ORG_AVATAR_CACHE) || "{}");
+  } catch (_) {
+    return {};
+  }
+}
+
+function escapeHtml(s) {
+  return s.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+main().catch((err) => {
+  const grid = document.getElementById("org-grid");
+  grid.innerHTML = `<div class="error">${escapeHtml(err.message)}</div>`;
+});

--- a/docs/gha-dashboard/entry.js
+++ b/docs/gha-dashboard/entry.js
@@ -1,13 +1,17 @@
 import { ensureAuthenticated, getToken, renderAuthHeader } from "./auth.js";
 
 const ORG_AVATAR_CACHE = "metanorma-actions-dashboard.orgAvatars";
+const UNSUB_KEY = "metanorma-actions-dashboard.unsubscribedOrgs";
+
+let ALL_ORGS = [];
 
 async function main() {
   await ensureAuthenticated();
   renderAuthHeader(document.getElementById("auth-header"));
-  const orgs = await loadOrgs();
-  renderTiles(orgs);
-  hydrateAvatars(orgs);
+  ALL_ORGS = await loadOrgs();
+  renderTiles();
+  renderManagePanel();
+  hydrateAvatars(ALL_ORGS);
 }
 
 async function loadOrgs() {
@@ -17,10 +21,28 @@ async function loadOrgs() {
   return body.orgs;
 }
 
-function renderTiles(orgs) {
+function readUnsubscribed() {
+  try {
+    return new Set(JSON.parse(localStorage.getItem(UNSUB_KEY) || "[]"));
+  } catch (_) {
+    return new Set();
+  }
+}
+
+function writeUnsubscribed(set) {
+  localStorage.setItem(UNSUB_KEY, JSON.stringify([...set]));
+}
+
+function renderTiles() {
   const grid = document.getElementById("org-grid");
   const cached = readAvatarCache();
-  grid.innerHTML = orgs
+  const unsub = readUnsubscribed();
+  const visible = ALL_ORGS.filter((o) => !unsub.has(o.name));
+  if (visible.length === 0) {
+    grid.innerHTML = `<div class="empty-subs">You've unsubscribed from every org. Use the panel below to subscribe to one or more.</div>`;
+    return;
+  }
+  grid.innerHTML = visible
     .map((org) => {
       const avatar = cached[org.name];
       const img = avatar
@@ -35,6 +57,32 @@ function renderTiles(orgs) {
       `;
     })
     .join("");
+}
+
+function renderManagePanel() {
+  const container = document.getElementById("manage-orgs");
+  if (!container) return;
+  const unsub = readUnsubscribed();
+  container.innerHTML = `
+    <p class="manage-hint">Untick orgs you don't want to see on this page. Stored in this browser only; doesn't affect other viewers.</p>
+    ${ALL_ORGS.map((org) => `
+      <label class="manage-row">
+        <input type="checkbox" data-org="${escapeHtml(org.name)}" ${unsub.has(org.name) ? "" : "checked"}>
+        <span class="manage-label">${escapeHtml(org.label)}</span>
+        <code class="manage-slug">${escapeHtml(org.name)}</code>
+      </label>
+    `).join("")}
+  `;
+  container.querySelectorAll('input[type="checkbox"]').forEach((cb) => {
+    cb.addEventListener("change", () => {
+      const slug = cb.dataset.org;
+      const set = readUnsubscribed();
+      if (cb.checked) set.delete(slug);
+      else set.add(slug);
+      writeUnsubscribed(set);
+      renderTiles();
+    });
+  });
 }
 
 async function hydrateAvatars(orgs) {

--- a/docs/gha-dashboard/index.html
+++ b/docs/gha-dashboard/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Active GitHub Actions runs</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body class="entry">
+  <header class="page-header">
+    <div class="page-header-row">
+      <h1>Active GitHub Actions runs</h1>
+      <div id="auth-header" class="auth-header"></div>
+    </div>
+    <p class="page-header-hint">Pick an org to see its in-progress and queued workflow runs.</p>
+  </header>
+  <main>
+    <div id="org-grid" class="org-grid"></div>
+  </main>
+  <script type="module" src="./entry.js"></script>
+</body>
+</html>

--- a/docs/gha-dashboard/index.html
+++ b/docs/gha-dashboard/index.html
@@ -16,6 +16,10 @@
   </header>
   <main>
     <div id="org-grid" class="org-grid"></div>
+    <details class="manage-orgs-panel">
+      <summary>Manage subscriptions</summary>
+      <div id="manage-orgs"></div>
+    </details>
   </main>
   <script type="module" src="./entry.js"></script>
 </body>

--- a/docs/gha-dashboard/orgs.json
+++ b/docs/gha-dashboard/orgs.json
@@ -1,0 +1,9 @@
+{
+  "orgs": [
+    { "name": "metanorma",  "label": "Metanorma" },
+    { "name": "relaton",    "label": "Relaton" },
+    { "name": "lutaml",     "label": "LutaML" },
+    { "name": "plurimath",  "label": "Plurimath" },
+    { "name": "claricle",   "label": "Claricle" }
+  ]
+}

--- a/docs/gha-dashboard/styles.css
+++ b/docs/gha-dashboard/styles.css
@@ -1,0 +1,239 @@
+:root {
+  --bg: #f6f8fa;
+  --panel: #ffffff;
+  --border: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  --accent: #0969da;
+  --status-running: #1f883d;
+  --status-queued: #9a6700;
+  --error: #d1242f;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  font-size: 14px;
+  color: var(--text);
+  background: var(--bg);
+}
+
+main { padding: 16px 24px 48px; }
+
+.page-header {
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+  padding: 16px 24px;
+}
+
+.page-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.page-header-left { display: flex; align-items: baseline; gap: 12px; }
+
+.page-header h1 { margin: 0; font-size: 18px; }
+
+.page-header-hint { color: var(--muted); margin: 8px 0 0; }
+
+.back-link { color: var(--accent); text-decoration: none; font-size: 13px; }
+.back-link:hover { text-decoration: underline; }
+
+.auth-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.auth-avatar { border-radius: 50%; }
+.auth-login { font-weight: 500; }
+.auth-signout {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 10px;
+  cursor: pointer;
+  font-size: 12px;
+}
+.auth-signout:hover { background: var(--bg); }
+.auth-pending { color: var(--muted); }
+
+.controls, .filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+
+.controls button, .filter-bar input[type="search"] {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 5px 10px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.controls button:hover { background: var(--bg); }
+.filter-bar input[type="search"] { cursor: text; min-width: 220px; }
+
+.control-label { color: var(--muted); font-size: 13px; display: inline-flex; align-items: center; gap: 4px; }
+.control-label select { font-size: 13px; }
+
+.rate-limit, .status-text, .active-count { color: var(--muted); font-size: 12px; }
+.status-text { min-width: 200px; }
+
+/* Entry page */
+.org-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.org-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+  padding: 20px 12px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color .15s, box-shadow .15s;
+}
+.org-tile:hover {
+  border-color: var(--accent);
+  box-shadow: 0 2px 8px rgba(9, 105, 218, 0.08);
+}
+
+.org-avatar { border-radius: 8px; }
+.org-avatar-placeholder {
+  width: 64px;
+  height: 64px;
+  border-radius: 8px;
+  background: var(--bg);
+  border: 1px dashed var(--border);
+}
+
+.org-label { font-weight: 600; font-size: 16px; }
+.org-name { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; color: var(--muted); }
+
+/* Dashboard table */
+table#runs {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+#runs th, #runs td {
+  padding: 8px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+#runs th {
+  background: var(--bg);
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+}
+#runs th[data-sort]:hover { background: #eaeef2; }
+#runs tbody tr:last-child td { border-bottom: 0; }
+#runs a { color: var(--accent); text-decoration: none; }
+#runs a:hover { text-decoration: underline; }
+
+.actor-avatar { border-radius: 50%; vertical-align: middle; margin-right: 4px; }
+
+.status {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.status-in_progress { color: var(--status-running); background: rgba(31, 136, 61, 0.12); }
+.status-queued { color: var(--status-queued); background: rgba(154, 103, 0, 0.12); }
+
+.elapsed { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+.empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--muted);
+}
+.empty-state p:first-child { font-size: 18px; color: var(--text); }
+.empty-count { font-size: 13px; }
+
+.error {
+  background: rgba(209, 36, 47, 0.08);
+  border: 1px solid var(--error);
+  color: var(--error);
+  padding: 12px 16px;
+  border-radius: 6px;
+  margin: 24px 0;
+}
+
+/* Device flow modal */
+#device-flow-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(31, 35, 40, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.device-flow-card {
+  background: var(--panel);
+  border-radius: 8px;
+  padding: 32px;
+  max-width: 400px;
+  text-align: center;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+.device-flow-card h2 { margin: 0 0 12px; font-size: 20px; }
+.device-flow-card a { color: var(--accent); }
+
+.device-flow-code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: 4px;
+  padding: 16px;
+  background: var(--bg);
+  border-radius: 6px;
+  margin: 16px 0;
+}
+
+.device-flow-card button {
+  display: inline-block;
+  margin: 4px;
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  cursor: pointer;
+  font-size: 14px;
+}
+.device-flow-open {
+  background: var(--accent) !important;
+  color: white;
+  border-color: var(--accent) !important;
+}
+
+.device-flow-hint { color: var(--muted); font-size: 12px; margin-top: 16px; }

--- a/docs/gha-dashboard/styles.css
+++ b/docs/gha-dashboard/styles.css
@@ -127,6 +127,58 @@ main { padding: 16px 24px 48px; }
 .org-label { font-weight: 600; font-size: 16px; }
 .org-name { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; color: var(--muted); }
 
+/* Subscription management */
+.empty-subs {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--muted);
+  background: var(--panel);
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+}
+
+.manage-orgs-panel {
+  margin-top: 32px;
+  max-width: 500px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 16px;
+}
+.manage-orgs-panel summary {
+  cursor: pointer;
+  font-weight: 500;
+  color: var(--muted);
+  user-select: none;
+}
+.manage-orgs-panel summary:hover { color: var(--text); }
+.manage-orgs-panel[open] summary { color: var(--text); margin-bottom: 8px; }
+
+.manage-hint {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 8px 0 12px;
+}
+
+.manage-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+  cursor: pointer;
+}
+.manage-row:hover .manage-label { color: var(--accent); }
+.manage-label { flex: 0 0 auto; font-size: 14px; }
+.manage-slug {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--bg);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
 /* Dashboard table */
 table#runs {
   width: 100%;

--- a/docs/gha-dashboard/styles.css
+++ b/docs/gha-dashboard/styles.css
@@ -187,8 +187,8 @@ table#runs {
   margin: 24px 0;
 }
 
-/* Device flow modal */
-#device-flow-modal {
+/* PAT sign-in modal */
+#pat-modal {
   position: fixed;
   inset: 0;
   background: rgba(31, 35, 40, 0.5);
@@ -198,42 +198,58 @@ table#runs {
   z-index: 100;
 }
 
-.device-flow-card {
+.pat-card {
   background: var(--panel);
   border-radius: 8px;
   padding: 32px;
-  max-width: 400px;
-  text-align: center;
+  max-width: 440px;
+  width: calc(100% - 32px);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
 }
-.device-flow-card h2 { margin: 0 0 12px; font-size: 20px; }
-.device-flow-card a { color: var(--accent); }
-
-.device-flow-code {
+.pat-card h2 { margin: 0 0 12px; font-size: 20px; }
+.pat-card p { margin: 8px 0; }
+.pat-card a { color: var(--accent); }
+.pat-card code {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 28px;
-  font-weight: 700;
-  letter-spacing: 4px;
-  padding: 16px;
+  font-size: 12px;
   background: var(--bg);
-  border-radius: 6px;
-  margin: 16px 0;
+  padding: 1px 4px;
+  border-radius: 3px;
 }
 
-.device-flow-card button {
-  display: inline-block;
-  margin: 4px;
-  padding: 8px 16px;
-  border-radius: 6px;
+.pat-input {
+  width: 100%;
+  padding: 8px 12px;
+  margin: 12px 0;
   border: 1px solid var(--border);
-  background: var(--panel);
+  border-radius: 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+}
+.pat-input:focus { outline: none; border-color: var(--accent); }
+
+.pat-submit {
+  display: block;
+  width: 100%;
+  padding: 10px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: white;
   cursor: pointer;
   font-size: 14px;
+  font-weight: 500;
 }
-.device-flow-open {
-  background: var(--accent) !important;
-  color: white;
-  border-color: var(--accent) !important;
+.pat-submit:disabled { opacity: 0.6; cursor: wait; }
+
+.pat-error {
+  color: var(--error);
+  font-size: 13px;
+  margin-top: 12px;
 }
 
-.device-flow-hint { color: var(--muted); font-size: 12px; margin-top: 16px; }
+.pat-hint {
+  color: var(--muted);
+  font-size: 12px;
+  margin-top: 16px;
+}


### PR DESCRIPTION
Implements the GitHub Actions live dashboard described in #29.

See #29 for the full design narrative, admin checklist (one item: enable Pages from `main:/docs`), and verification plan. The Client ID in `docs/gha-dashboard/auth.js` is still a placeholder — needs replacing once the OAuth App is registered.
